### PR TITLE
Fix ggplot2 deprecations

### DIFF
--- a/R/base_figure.R
+++ b/R/base_figure.R
@@ -84,8 +84,8 @@ whittaker_base_plot <- function(color_palette = NULL) {
                                        y    = precp_cm,
                                        fill = biome),
                           # adjust polygon border
-                          colour = "gray98",
-                          size   = 1) +
+                          colour    = "gray98",
+                          linewidth = 1) +
   # fill the polygons with predefined colors
     ggplot2::scale_fill_manual(name   = "Whittaker biomes",
                                breaks = names(color_palette),

--- a/tests/testthat/test-base_plot.R
+++ b/tests/testthat/test-base_plot.R
@@ -18,7 +18,8 @@ test_that('function and arguments work correctly', {
                  regexp = "Names for 'color_palette'")
 
   tlc_legend <- whittaker_base_plot() +
-    theme(legend.position = c(0.2, 0.75),
+    theme(legend.position = "inside",
+    	  legend.position.inside = c(0.2, 0.75),
           panel.background = element_blank(),
           panel.grid.major = element_line(gray(0.2)),
           panel.border = element_rect(fill = NA))


### PR DESCRIPTION
There were two warnings due to ggplot2 deprecations. This change fixes them:

- Update `size` to `linewidth`, as `linewidth`is now the recommended aesthetic. [Reference](https://www.tidyverse.org/blog/2022/08/ggplot2-3-4-0-size-to-linewidth/).
- Modified the test file, as numeric arguments for `legend.position` [were deprecated](https://www.tidyverse.org/blog/2024/02/ggplot2-3-5-0-legends/#placement).